### PR TITLE
Allow host/port configuration to be pulled from environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ config :logger,
 
 config :logger, :logstash,
   level: :debug,
-  host: System.get_env("LOGSTASH_TCP_HOST") || "localhost",
-  port: System.get_env("LOGSTASH_TCP_PORT") || "4560",
+  host: {:system, "LOGSTASH_TCP_HOST", "localhost"},
+  port: {:system, "LOGSTASH_TCP_PORT", "4560"},
   fields: %{appid: "schuppen"}
 ```
 

--- a/lib/logstash_json_tcp.ex
+++ b/lib/logstash_json_tcp.ex
@@ -41,8 +41,8 @@ defmodule LogstashJson.TCP do
     Application.put_env(:logger, name, opts)
 
     level      = Keyword.get(opts, :level) || :debug
-    host       = opts |> Keyword.get(:host) |> env_host |> to_char_list
-    port       = env_int(Keyword.get(opts, :port))
+    host       = opts |> Keyword.get(:host) |> env_var |> to_char_list
+    port       = opts |> Keyword.get(:port) |> env_var |> to_int
     metadata   = Keyword.get(opts, :metadata) || []
     fields     = Keyword.get(opts, :fields) || %{}
 
@@ -57,21 +57,27 @@ defmodule LogstashJson.TCP do
       name: name}
   end
 
-  defp env_host({:system, var, default}) do
+  defp env_var({:system, var, default}) do
     case System.get_env(var) do
       nil -> default
       value -> value
     end
   end
-  defp env_host({:system, var}) do
+  defp env_var({:system, var}) do
     System.get_env(var)
   end
-  defp env_host(value) when is_string(value) do
+  defp env_var(value) do
     value
   end
 
-  defp env_int(e) when is_integer(e), do: e
-  defp env_int(e), do: Integer.parse(e) |> elem(0)
+  defp to_int(val) when is_integer(val) do
+    val
+  end
+  defp to_int(val) do
+    val
+    |> Integer.parse
+    |> elem(0)
+  end
 
   @connection_opts [mode: :binary, keepalive: true]
   defp connect(host, port) do

--- a/lib/logstash_json_tcp.ex
+++ b/lib/logstash_json_tcp.ex
@@ -41,7 +41,7 @@ defmodule LogstashJson.TCP do
     Application.put_env(:logger, name, opts)
 
     level      = Keyword.get(opts, :level) || :debug
-    host       = to_char_list(Keyword.get(opts, :host))
+    host       = opts |> Keyword.get(:host) |> env_host |> to_char_list
     port       = env_int(Keyword.get(opts, :port))
     metadata   = Keyword.get(opts, :metadata) || []
     fields     = Keyword.get(opts, :fields) || %{}
@@ -55,6 +55,19 @@ defmodule LogstashJson.TCP do
       conn: conn,
       fields: fields,
       name: name}
+  end
+
+  defp env_host({:system, var, default}) do
+    case System.get_env(var) do
+      nil -> default
+      value -> value
+    end
+  end
+  defp env_host({:system, var}) do
+    System.get_env(var)
+  end
+  defp env_host(value) when is_string(value) do
+    value
   end
 
   defp env_int(e) when is_integer(e), do: e


### PR DESCRIPTION
Since config files are evaluated when a release is built and not at runtime, this change will allow of reading environment variables at runtime.
