### PR TITLE
Spawn multiple TCP workers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,8 +40,8 @@ config :logger, :logstash,
   host: System.get_env("LOGSTASH_TCP_HOST") || "localhost",
   port: System.get_env("LOGSTASH_TCP_PORT") || "4560",
   fields: %{appid: "logstash-json"},
-  workers: 4,
-  buffer_size: 100_000
+  workers: 2,
+  buffer_size: 10_000
 
 config :logger, :json,
   level: :info

--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,9 @@ config :logger, :logstash,
   level: :debug,
   host: System.get_env("LOGSTASH_TCP_HOST") || "localhost",
   port: System.get_env("LOGSTASH_TCP_PORT") || "4560",
-  fields: %{appid: "logstash-json"}
+  fields: %{appid: "logstash-json"},
+  workers: 4,
+  buffer_size: 100_000
 
 config :logger, :json,
   level: :info

--- a/lib/connection/tcp.ex
+++ b/lib/connection/tcp.ex
@@ -10,37 +10,42 @@ defmodule LogstashJson.TCP.Connection do
   size is reached after which incoming messages are dropped.
   """
 
-  def start_link(host, port, opts, timeout \\ 1_000, buffer_max \\ 10_000) do
-    Connection.start_link(__MODULE__, {host, port, opts, timeout, buffer_max})
+  @connection_opts [active: false, mode: :binary, keepalive: true, packet: 0]
+
+  def start_link(host, port, queue, timeout \\ 1_000) do
+    Connection.start_link(__MODULE__, {host, port, queue, timeout})
   end
 
-  @doc "Asynchronous sending of a message"
-  def send(conn, data), do: Connection.cast(conn, {:send, data})
+  @doc "Send message to logstash backend"
+  def send(conn, data, timeout \\ 5_000) do
+    Connection.call(conn, {:send, data}, timeout)
+  end
 
   @doc "Close connection"
   def close(conn), do: Connection.call(conn, :close)
 
   @doc "Update configuration and reconnect"
-  def configure(conn, host, port, opts) do
-    Connection.call(conn, {:configure, host, port, opts})
+  def configure(conn, host, port) do
+    Connection.call(conn, {:configure, host, port})
   end
 
-  def init({host, port, opts, timeout, buffer_max}) do
+  def init({host, port, queue, timeout}) do
+    LogstashJson.TCP.Connection.Worker.start_link(self(), queue)
+
     state = %{
       host: host,
       port: port,
-      opts: opts,
       timeout: timeout,
-      sock: nil,
-      buffer: [],
-      buffer_max: buffer_max}
+      sock: nil}
     {:connect, :init, state}
   end
 
-  def connect(_, %{sock: nil, host: host, port: port, opts: opts, timeout: timeout} = state) do
-    case :gen_tcp.connect(host, port, [active: false] ++ opts, timeout) do
+  def connect(_, %{sock: nil, host: host, port: port, timeout: timeout} = state) do
+    case :gen_tcp.connect(host, port, @connection_opts, timeout) do
       {:ok, sock} ->
         {:ok, %{state | sock: sock}}
+      {:error, :econnrefused} ->
+        {:backoff, 1000, state}
       {:error, reason} ->
         connect_error_log(reason, host, port)
         {:backoff, 1000, state}
@@ -58,20 +63,19 @@ defmodule LogstashJson.TCP.Connection do
     {:connect, :reconnect, %{state | sock: nil}}
   end
 
-  def handle_cast({:send, data}, %{sock: nil} = state) do
-    {:noreply, buffer_data(data, state)}
+  def handle_call({:send, _data}, _from, %{sock: nil} = state) do
+    {:reply, :ok, state}
   end
 
-  def handle_cast({:send, data}, %{sock: sock, buffer: buffer} = state) do
-    data_send = Enum.join([data | buffer])
-    case :gen_tcp.send(sock, data_send) do
+  def handle_call({:send, data}, _from, %{sock: sock} = state) do
+    case :gen_tcp.send(sock, data) do
       :ok ->
-        {:noreply, %{state | buffer: []}}
+        {:reply, :ok, state}
       {:error, :closed} = error ->
-        {:disconnect, error, buffer_data(data, state)}
+        {:disconnect, error, error, state}
       {:error, reason} = error ->
         send_error_log(reason)
-        {:disconnect, error, buffer_data(data, state)}
+        {:disconnect, error, error, state}
     end
   end
 
@@ -79,11 +83,16 @@ defmodule LogstashJson.TCP.Connection do
     {:disconnect, {:close, from}, state}
   end
 
-  def handle_call({:configure, host, port, opts}, from, state) do
+  def handle_call({:configure, host, port}, from, state) do
     {:disconnect, {:close, from}, %{state |
       host: host,
-      port: port,
-      opts: opts}}
+      port: port}}
+  end
+
+  def terminate(_, %{sock: sock} = state) do
+    if sock != nil do
+      :ok = :gen_tcp.close(sock)
+    end
   end
 
   defp connect_error_log(reason, host, port) do
@@ -101,12 +110,21 @@ defmodule LogstashJson.TCP.Connection do
     reason = :inet.format_error(reason)
     IO.puts "#{__MODULE__}: error sending over TCP: #{reason}"
   end
+end
 
-  defp buffer_data(data, %{buffer: buffer, buffer_max: max} = state) do
-    if length(buffer) < max do
-      %{state | buffer: [data | buffer]}
-    else
-      state
-    end
+defmodule LogstashJson.TCP.Connection.Worker do
+  @moduledoc """
+  Worker that reads log messages from a BlockingQueue and writes them to
+  logstash using a TCP connection.
+  """
+
+  def start_link(conn, queue) do
+    spawn_link fn -> consume_messages(conn, queue) end
+  end
+
+  defp consume_messages(conn, queue) do
+    msg = BlockingQueue.pop(queue)
+    LogstashJson.TCP.Connection.send(conn, msg, 60_000)
+    consume_messages(conn, queue)
   end
 end

--- a/lib/logstash_json_tcp.ex
+++ b/lib/logstash_json_tcp.ex
@@ -93,6 +93,6 @@ defmodule LogstashJson.TCP do
   defp to_int(val), do: val |> Integer.parse |> elem(0)
 
   defp tcp_worker(id, host, port, queue) do
-    worker(TCP.Connection, [host, port, queue], id: id)
+    worker(TCP.Connection, [host, port, queue, id], id: id)
   end
 end

--- a/lib/logstash_json_tcp.ex
+++ b/lib/logstash_json_tcp.ex
@@ -60,9 +60,9 @@ defmodule LogstashJson.TCP do
     port        = opts |> Keyword.get(:port) |> env_var |> to_int
     metadata    = Keyword.get(opts, :metadata) || []
     fields      = Keyword.get(opts, :fields) || %{}
-    workers     = Keyword.get(opts, :workers) || 4
+    workers     = Keyword.get(opts, :workers) || 2
     worker_pool = Keyword.get(opts, :worker_pool) || nil
-    buffer_size = Keyword.get(opts, :buffer_size) || 100_000
+    buffer_size = Keyword.get(opts, :buffer_size) || 10_000
 
     # Close previous worker pool
     if worker_pool != nil do

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule LogstashJson.Mixfile do
   defp deps do
     [{:connection, "~> 1.0.3"},
      {:poison, "~> 2.1"},
+     {:blocking_queue, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+%{"blocking_queue": {:hex, :blocking_queue, "1.3.0", "dc89343242db43b3a5618c41b258795f8e8258ec528a763e70ceb2763bd96b92", [:mix], []},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}

--- a/test/tcp_connection_test.exs
+++ b/test/tcp_connection_test.exs
@@ -2,46 +2,45 @@ defmodule TcpConnectionTest do
   use ExUnit.Case, async: false
   require Logger
 
-  @connection_opts [mode: :binary, keepalive: true]
-
   test "Sends message when connection open" do
     {listener, port} = new_listener()
 
-    {:ok, conn} = LogstashJson.TCP.Connection.start_link('localhost', port, @connection_opts)
+    {:ok, queue} = BlockingQueue.start_link(1)
+    {:ok, conn} = LogstashJson.TCP.Connection.start_link('localhost', port, queue)
     LogstashJson.TCP.Connection.send(conn, "foobar")
 
     msg = recv_and_close(listener)
     assert msg == "foobar"
   end
 
-  test "Buffers data when no connection, sends buffer when connection opens" do
-    {:ok, conn} = LogstashJson.TCP.Connection.start_link('no_such_host', 1, @connection_opts)
+  test "Drops data when no connection" do
+    {:ok, queue} = BlockingQueue.start_link(3)
+    {:ok, conn} = LogstashJson.TCP.Connection.start_link('localhost', 1, queue)
     LogstashJson.TCP.Connection.send(conn, "One\n")
     LogstashJson.TCP.Connection.send(conn, "Two\n")
 
     {listener, port} = new_listener()
-    LogstashJson.TCP.Connection.configure(conn, 'localhost', port, @connection_opts)
+    LogstashJson.TCP.Connection.configure(conn, 'localhost', port)
 
+    {:ok, socket} = :gen_tcp.accept(listener, 1000)
     LogstashJson.TCP.Connection.send(conn, "Three\n")
+    {:ok, msg} = :gen_tcp.recv(socket, 0, 5000)
+    :ok = :gen_tcp.close socket
+    :ok = :gen_tcp.close listener
 
-    msg = recv_and_close(listener)
-    assert msg == "Three\nTwo\nOne\n"
+    # msg = recv_and_close(listener)
+    assert msg == "Three\n"
   end
 
-  test "Drops message if buffer full" do
-    {:ok, conn} = LogstashJson.TCP.Connection.start_link('no_such_host', 1, @connection_opts, 1000, 2)
-    LogstashJson.TCP.Connection.send(conn, "One\n")
-    LogstashJson.TCP.Connection.send(conn, "Two\n")
-    LogstashJson.TCP.Connection.send(conn, "Three\n")
-    LogstashJson.TCP.Connection.send(conn, "Four")
-
+  test "Consumes messages from queue" do
     {listener, port} = new_listener()
-    LogstashJson.TCP.Connection.configure(conn, 'localhost', port, @connection_opts)
 
-    LogstashJson.TCP.Connection.send(conn, "Hello\n")
+    {:ok, queue} = BlockingQueue.start_link(1)
+    {:ok, _conn} = LogstashJson.TCP.Connection.start_link('localhost', port, queue)
+    BlockingQueue.push(queue, "foobar")
 
     msg = recv_and_close(listener)
-    assert msg == "Hello\nTwo\nOne\n"
+    assert msg == "foobar"
   end
 
   defp new_listener() do


### PR DESCRIPTION
This commit makes the TCP logger backend spawn multiple worker processes. Each worker creates a new TCP connection.

When a message is logged, it is sent to a BlockingQueue message buffer, which all worker processes consume from. The buffer has a max limit, if it is reached new logs will block until space is available in the buffer.

The purpose of this change is to:
- increase throughput, for example when there are several logstash instances behind a load balancer.
- avoid running out of memory when logs are produced faster than they are consumed.
- introduce blocking behaviour on full buffer instead of dropping messages.
