### PR TITLE
Allow use of `utc_log` Logger configuration

### DIFF
--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -5,9 +5,9 @@ defmodule LogstashJson.Event do
   """
 
   @doc "Generate a log event from log data"
-  def event(level, msg, ts, md, %{metadata: metadata, fields: fields}) do
+  def event(level, msg, ts, md, %{metadata: metadata, fields: fields, utc_log: utc_log}) do
     Map.merge(fields, %{
-      "@timestamp": timestamp(ts),
+      "@timestamp": timestamp(ts, utc_log),
       level: level,
       message: to_string(msg),
       metadata: take_metadata(md, metadata),
@@ -32,11 +32,17 @@ defmodule LogstashJson.Event do
   end
 
   # Functions for generating timestamp
-  defp timestamp({{year, month, day}, {hour, min, sec, millis}}) do
-    pad(year, 4) <> "-" <> pad(month, 2) <> "-" <> pad(day, 2) <> "T" <>
-      pad(hour, 2) <> ":" <> pad(min, 2) <> ":" <> pad(sec, 2) <> "." <> pad(millis, 3) <>
-      timezone()
+  defp timestamp(ts, utc_log) do
+    datetime(ts) <> timezone(utc_log)
   end
+
+  defp datetime({{year, month, day}, {hour, min, sec, millis}}) do
+    pad(year, 4) <> "-" <> pad(month, 2) <> "-" <> pad(day, 2) <> "T" <>
+      pad(hour, 2) <> ":" <> pad(min, 2) <> ":" <> pad(sec, 2) <> "." <> pad(millis, 3)
+  end
+
+  defp timezone(_utc_true = true), do: "+00:00"
+  defp timezone(_), do: timezone
 
   defp timezone() do
     offset = timezone_offset()

--- a/lib/logstash_json_console.ex
+++ b/lib/logstash_json_console.ex
@@ -41,8 +41,9 @@ defmodule LogstashJson.Console do
     level    = Keyword.get(opts, :level)
     metadata = Keyword.get(opts, :metadata) || []
     fields   = Keyword.get(opts, :fields) || %{}
+    utc_log  = Application.get_env(:logger, :utc_log, false)
 
-    %{metadata: metadata, level: level, fields: fields}
+    %{metadata: metadata, level: level, fields: fields, utc_log: utc_log}
   end
 
   defp log_event(level, msg, ts, md, state) do

--- a/lib/logstash_json_tcp.ex
+++ b/lib/logstash_json_tcp.ex
@@ -63,6 +63,7 @@ defmodule LogstashJson.TCP do
     workers     = Keyword.get(opts, :workers) || 2
     worker_pool = Keyword.get(opts, :worker_pool) || nil
     buffer_size = Keyword.get(opts, :buffer_size) || 10_000
+    utc_log     = Application.get_env(:logger, :utc_log, false)
 
     # Close previous worker pool
     if worker_pool != nil do
@@ -82,7 +83,8 @@ defmodule LogstashJson.TCP do
       fields: fields,
       name: name,
       queue: queue,
-      worker_pool: worker_pool}
+      worker_pool: worker_pool,
+      utc_log: utc_log}
   end
 
   defp env_var({:system, var, default}), do: System.get_env(var) || default

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -23,6 +23,15 @@ defmodule EventTest do
     assert Map.get(event, :foo) == "bar"
   end
 
+  test "Adds no timezone offset for utc_log" do
+    event = Event.event(:info, "", {{2015,1,1},{0,0,0,0}}, [], %{
+      metadata: [],
+      fields: %{},
+      utc_log: true
+    })
+    assert Map.get(event, :"@timestamp") =~ "+00:00"
+  end
+
   test "Converts event to json" do
     message = "Meowson the third"
     event = log_json(message) |> Poison.decode!()
@@ -44,7 +53,8 @@ defmodule EventTest do
   defp log(msg, fields \\ %{}) do
     Event.event(:info, msg, {{2015,1,1},{0,0,0,0}}, [], %{
       metadata: [],
-      fields: fields
+      fields: fields,
+      utc_log: false
     })
   end
 


### PR DESCRIPTION
We noticed the timestamps of some of our elixir applications we off by about two hours. After doing a bit of digging it appears to be happening because logstash-json is attempting to convert our UTC timestamps to UTC, even though they're already UTC timestamps.

Here's what's happening:
* We're using the `utc_logs = true` as part of the [Runtime Configuration](https://hexdocs.pm/logger/Logger.html#module-configuration) of Logger. 
* Our application is running in a UTC+02:00 time zone. 
* When logstash-json creates an `Event` from the log event, it compares the difference between UTC time and the local time of the application and adds this as an offset to the timestamp 
* The event that gets createed results in all our log entries being 2 hours older than they should be.

This PR checks if `utc_logs = true` is set in the `:logger` config.
E.g.
```yml
config :logger,
  truncate: :infinity,
  utc_log: true,
  ...
```
If it's `true` it sets the offset to `"+00:00"`. If it's `false` or not set, it calculates the offset as it did previously.