### PR TITLE
Fix Elixir 1.5 warnings

### DIFF
--- a/lib/logstash_json_console.ex
+++ b/lib/logstash_json_console.ex
@@ -1,18 +1,21 @@
 defmodule LogstashJson.Console do
-  use GenEvent
-
   @moduledoc """
   Logger backend which prints logs to stdout in JSON format.
   """
 
+  @behaviour :gen_event
+
+  @doc false
   def init({__MODULE__, name}) do
     {:ok, configure(name, [])}
   end
 
+  @doc false
   def handle_call({:configure, opts}, %{name: name}) do
     {:ok, :ok, configure(name, opts)}
   end
 
+  @doc false
   def handle_event(:flush, state) do
     {:ok, state}
   end
@@ -28,8 +31,19 @@ defmodule LogstashJson.Console do
     {:ok, state}
   end
 
+  @doc false
+  def handle_info(_msg, state) do
+    {:ok, state}
+  end
+
+  @doc false
   def terminate(_reason, _state) do
     :ok
+  end
+
+  @doc false
+  def code_change(_reason, state, _extra) do
+    {:ok, state}
   end
 
   ## Helpers

--- a/test/logstash_json_console_test.exs
+++ b/test/logstash_json_console_test.exs
@@ -12,7 +12,7 @@ defmodule LogstashJsonConsoleTest do
     io = capture_io(fn ->
       logger = new_logger()
       log(logger, "Hello world!")
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     event = Poison.decode!(io)
@@ -24,7 +24,7 @@ defmodule LogstashJsonConsoleTest do
     io = capture_io(fn ->
       logger = new_logger()
       log(logger, "Hello world!")
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     assert io |> String.ends_with?("\n")
@@ -34,7 +34,7 @@ defmodule LogstashJsonConsoleTest do
     io = capture_io(fn ->
       logger = new_logger()
       log(logger, "Hello world!", :warn)
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     event = Poison.decode!(io)
@@ -47,7 +47,7 @@ defmodule LogstashJsonConsoleTest do
       log(logger, "Hello world!")
       log(logger, "Foo?")
       log(logger, "Bar!")
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     lines = io |> String.trim() |> String.split("\n") |> List.to_tuple()
@@ -61,7 +61,7 @@ defmodule LogstashJsonConsoleTest do
     io = capture_io(fn ->
       logger = new_logger()
       log(logger, "Hello world!", :info, [car: "Lamborghini"])
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     event = Poison.decode!(io)
@@ -76,7 +76,7 @@ defmodule LogstashJsonConsoleTest do
     io = capture_io(fn ->
       logger = new_logger()
       log(logger, "Hello world!")
-      GenEvent.stop(logger)
+      :gen_event.stop(logger)
     end)
 
     event = Poison.decode!(io)
@@ -84,14 +84,14 @@ defmodule LogstashJsonConsoleTest do
   end
 
   defp new_logger do
-    {:ok, manager} = GenEvent.start_link()
-    GenEvent.add_handler(manager, LogstashJson.Console, {LogstashJson.Console, :json})
+    {:ok, manager} = :gen_event.start_link()
+    :gen_event.add_handler(manager, LogstashJson.Console, {LogstashJson.Console, :json})
     manager
   end
 
   defp log(logger, msg, level \\ :info, metadata \\ []) do
     ts = {{2017, 1, 1}, {1, 2, 3, 400}}
-    GenEvent.notify(logger, {level, logger, {Logger, msg, ts, metadata}})
+    :gen_event.notify(logger, {level, logger, {Logger, msg, ts, metadata}})
     Process.sleep(100) #GenEvent.notify is async, must wait for IO to appear
   end
 end

--- a/test/logstash_json_tcp_test.exs
+++ b/test/logstash_json_tcp_test.exs
@@ -12,7 +12,7 @@ defmodule LogstashJsonTcpTest do
     log(logger, "Hello world!")
 
     msg = recv_and_close(listener)
-    GenEvent.stop(logger)
+    :gen_event.stop(logger)
 
     event = Poison.decode!(msg)
     assert event["message"] == "Hello world!"
@@ -25,7 +25,7 @@ defmodule LogstashJsonTcpTest do
     log(logger, "Hello world!")
 
     msg = recv_and_close(listener)
-    GenEvent.stop(logger)
+    :gen_event.stop(logger)
 
     assert msg |> String.ends_with?("\n")
   end
@@ -42,7 +42,7 @@ defmodule LogstashJsonTcpTest do
     msg = recv_all(socket)
     :ok = :gen_tcp.close socket
     :ok = :gen_tcp.close listener
-    GenEvent.stop(logger)
+    :gen_event.stop(logger)
 
     lines = msg |> String.trim() |> String.split("\n") |> List.to_tuple()
     assert tuple_size(lines) == 3
@@ -57,7 +57,7 @@ defmodule LogstashJsonTcpTest do
     log(logger, "Hello world!", :info, [car: "Lamborghini"])
 
     msg = recv_and_close(listener)
-    GenEvent.stop(logger)
+    :gen_event.stop(logger)
 
     event = Poison.decode!(msg)
     assert event["metadata"]["car"]  == "Lamborghini"
@@ -72,7 +72,7 @@ defmodule LogstashJsonTcpTest do
     log(logger, "Hello world!", :info, [car: "Lamborghini"])
 
     msg = recv_and_close(listener)
-    GenEvent.stop(logger)
+    :gen_event.stop(logger)
 
     event = Poison.decode!(msg)
     assert event["test_field"] == "test_value"
@@ -88,8 +88,8 @@ defmodule LogstashJsonTcpTest do
     opts = :logger |> Application.get_env(:logstash) |> Keyword.put(:port, "#{port}")
     Application.put_env(:logger, :logstash, opts)
 
-    {:ok, manager} = GenEvent.start_link()
-    GenEvent.add_handler(manager, LogstashJson.TCP, {LogstashJson.TCP, :logstash})
+    {:ok, manager} = :gen_event.start_link()
+    :gen_event.add_handler(manager, LogstashJson.TCP, {LogstashJson.TCP, :logstash})
     manager
   end
 
@@ -110,6 +110,6 @@ defmodule LogstashJsonTcpTest do
 
   defp log(logger, msg, level \\ :info, metadata \\ []) do
     ts = {{2017, 1, 1}, {1, 2, 3, 400}}
-    GenEvent.notify(logger, {level, logger, {Logger, msg, ts, metadata}})
+    :gen_event.notify(logger, {level, logger, {Logger, msg, ts, metadata}})
   end
 end


### PR DESCRIPTION
Elixir 1.5 deprecated `GenEvent` (it now prints a lot of warnings on use)
and `Kernel.to_char_list/1` (in favor of `to_charlist/1`). This commit
fixes all of those warnings.