### PR TITLE
Add metadata to top level fields to generate indexable attributes for Kibana

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config :logger, :json,
 ```
 
 #### Passing additional Metadata
-Using `Logger.metadata/1` it is possible to send additional information that can be sent as a part of a log statement. These will appear in Kibana as separate fields. An example is to send HTTP status codes or request duration details.
+Using `Logger.metadata/1` it is possible to send additional information that can be sent as a part of a log statement. These will appear in Kibana as top level fields and also collected in a separate field. An example is to send HTTP status codes or request duration details.
 Metadata can also be appended with the second argument of `Logger.info/2`.
 
 ```Elixir
@@ -74,23 +74,9 @@ iex(2)> Logger.metadata([status: 200, method: "GET"])
 :ok
 iex(3)> Logger.info "Test"
 :ok
-{"module":null,"metadata":{"status":200,"pid":"#PID<0.157.0>","module":null,"method":"GET","line":3,"function":null,"file":"iex"},"message":"Test","line":3,"level":"info","function":null,"@timestamp":"2017-05-15T16:12:26.568+02:00"}
+{"status":200,"pid":"#PID<0.160.0>","module":null,"method":"GET","metadata":{"status":200,"pid":"#PID<0.160.0>","module":null,"method":"GET","line":3,"function":null,"file":"iex"},"message":"Test","line":3,"level":"info","function":null,"file":"iex","@timestamp":"2017-08-09T15:48:13.941+02:00"}
 iex(4)> Logger.info "Test", [foo: "bar"]
-{"module":null,"metadata":{"status":200,"pid":"#PID<0.157.0>","module":null,"method":"GET","line":4,"function":null,"foo":"bar","file":"iex"},"message":"Test","line":4,"level":"info","function":null,"@timestamp":"2017-05-15T16:13:18.254+02:00"}
-```
-
-By adding a special key, `include_in_parent`, it is possible to add additional fields to the JSON payload. This will not override fields already there.
-
-```Elixir
-iex(1)> require Logger
-Logger
-iex(2)> Logger.metadata([include_in_parent: %{add_this: "to_parent"}])
-:ok
-iex(3)> Logger.info "Test"
-:ok
-{"module":null,"metadata":{"pid":"#PID<0.149.0>","module":null,"line":3,"function":null,"file":"iex"},"message":"Test","line":3,"level":"info","function":null,"add_this":"to_parent","@timestamp":"2017-08-08T12:22:12.664+02:00"}
-iex(4)> Logger.info "Test", [include_in_parent: %{foo: "bar"}]
-{"module":null,"metadata":{"pid":"#PID<0.149.0>","module":null,"line":5,"function":null,"file":"iex"},"message":"Test","line":5,"level":"info","function":null,"foo":"bar","@timestamp":"2017-08-08T12:22:54.789+02:00"}
+{"status":200,"pid":"#PID<0.160.0>","module":null,"method":"GET","metadata":{"status":200,"pid":"#PID<0.160.0>","module":null,"method":"GET","line":5,"function":null,"foo":"bar","file":"iex"},"message":"Test","line":5,"level":"info","function":null,"foo":"bar","file":"iex","@timestamp":"2017-08-09T15:48:36.910+02:00"}
 ```
  
 Here is an example plug for setting the Metadata

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ iex(4)> Logger.info "Test", [foo: "bar"]
 {"module":null,"metadata":{"status":200,"pid":"#PID<0.157.0>","module":null,"method":"GET","line":4,"function":null,"foo":"bar","file":"iex"},"message":"Test","line":4,"level":"info","function":null,"@timestamp":"2017-05-15T16:13:18.254+02:00"}
 ```
 
+By adding a special key, `include_in_parent`, it is possible to add additional fields to the JSON payload. This will not override fields already there.
+
+```Elixir
+iex(1)> require Logger
+Logger
+iex(2)> Logger.metadata([include_in_parent: %{add_this: "to_parent"}])
+:ok
+iex(3)> Logger.info "Test"
+:ok
+{"module":null,"metadata":{"pid":"#PID<0.149.0>","module":null,"line":3,"function":null,"file":"iex"},"message":"Test","line":3,"level":"info","function":null,"add_this":"to_parent","@timestamp":"2017-08-08T12:22:12.664+02:00"}
+iex(4)> Logger.info "Test", [include_in_parent: %{foo: "bar"}]
+{"module":null,"metadata":{"pid":"#PID<0.149.0>","module":null,"line":5,"function":null,"file":"iex"},"message":"Test","line":5,"level":"info","function":null,"foo":"bar","@timestamp":"2017-08-08T12:22:54.789+02:00"}
+```
+ 
 Here is an example plug for setting the Metadata
 
 ```Elixir

--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -14,8 +14,7 @@ defmodule LogstashJson.Event do
         metadata: format_metadata(md),
         module: md[:module],
         function: md[:function],
-        line: md[:line],
-        include_in_parent: md[:include_in_parent]
+        line: md[:line]
       }
     )
   end
@@ -28,20 +27,18 @@ defmodule LogstashJson.Event do
   def format_fields(fields, field_overrides) do
     fields
     |> Map.merge(field_overrides)
-    |> include_in_parent(field_overrides[:include_in_parent])
-    |> Map.delete(:include_in_parent)
+    |> include_in_parent(field_overrides[:metadata])
   end
 
   defp format_metadata(metadata) do
     metadata
     |> Enum.into(%{})
-    |> Map.delete(:include_in_parent)
   end
 
   defp include_in_parent(fields, nil), do: fields
   defp include_in_parent(fields, metadata) do
     fields
-    |> Map.merge(Map.drop(format_metadata(metadata), Map.keys(fields)))
+    |> Map.merge(Map.drop(metadata, Map.keys(fields)))
   end
 
   # Functions for generating timestamp

--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -6,15 +6,18 @@ defmodule LogstashJson.Event do
 
   @doc "Generate a log event from log data"
   def event(level, msg, ts, md, %{fields: fields, utc_log: utc_log}) do
-    Map.merge(fields, %{
-      "@timestamp": timestamp(ts, utc_log),
-      level: level,
-      message: to_string(msg),
-      metadata: format_metadata(md),
-      module: md[:module],
-      function: md[:function],
-      line: md[:line]
-    })
+    fields
+    |> format_fields(%{
+        "@timestamp": timestamp(ts, utc_log),
+        level: level,
+        message: to_string(msg),
+        metadata: format_metadata(md),
+        module: md[:module],
+        function: md[:function],
+        line: md[:line],
+        include_in_parent: md[:include_in_parent]
+      }
+    )
   end
 
   @doc "Serialize a log event to a JSON string"
@@ -22,8 +25,23 @@ defmodule LogstashJson.Event do
     event |> print_pids |> Poison.encode()
   end
 
+  def format_fields(fields, field_overrides) do
+    fields
+    |> Map.merge(field_overrides)
+    |> include_in_parent(field_overrides[:include_in_parent])
+    |> Map.delete(:include_in_parent)
+  end
+
   defp format_metadata(metadata) do
-    metadata |> Enum.into(%{})
+    metadata
+    |> Enum.into(%{})
+    |> Map.delete(:include_in_parent)
+  end
+
+  defp include_in_parent(fields, nil), do: fields
+  defp include_in_parent(fields, metadata) do
+    fields
+    |> Map.merge(Map.drop(format_metadata(metadata), Map.keys(fields)))
   end
 
   # Functions for generating timestamp

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -23,22 +23,13 @@ defmodule EventTest do
     assert Map.get(event, :foo) == "bar"
   end
 
-  test "Joins extra fields defined in include_in_parent but does not overwrite existing fields" do
+  test "Joins metadata fields but does not overwrite existing fields" do
     message = "Meow the second"
-    event = log(message, %{}, [include_in_parent: %{foo: "bar", level: "fail", message: "fail"}])
+    event = log(message, %{}, [foo: "bar", level: "fail", message: "fail"])
 
     assert Map.get(event, :message) == message
     assert Map.get(event, :level) == :info
     assert Map.get(event, :foo) == "bar"
-  end
-
-  test "Joins extra fields defined in include_in_parent and removes from metadata" do
-    message = "Meow the second"
-    event = log(message, %{}, [include_in_parent: %{foo: "bar"}])
-
-    assert Map.get(event, :message) == message
-    assert Map.get(event, :foo) == "bar"
-    assert Map.get(event, :include_in_parent) == nil
   end
 
   test "Adds no timezone offset for utc_log" do

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -23,6 +23,24 @@ defmodule EventTest do
     assert Map.get(event, :foo) == "bar"
   end
 
+  test "Joins extra fields defined in include_in_parent but does not overwrite existing fields" do
+    message = "Meow the second"
+    event = log(message, %{}, [include_in_parent: %{foo: "bar", level: "fail", message: "fail"}])
+
+    assert Map.get(event, :message) == message
+    assert Map.get(event, :level) == :info
+    assert Map.get(event, :foo) == "bar"
+  end
+
+  test "Joins extra fields defined in include_in_parent and removes from metadata" do
+    message = "Meow the second"
+    event = log(message, %{}, [include_in_parent: %{foo: "bar"}])
+
+    assert Map.get(event, :message) == message
+    assert Map.get(event, :foo) == "bar"
+    assert Map.get(event, :include_in_parent) == nil
+  end
+
   test "Adds no timezone offset for utc_log" do
     event = Event.event(:info, "", {{2015, 1, 1}, {0, 0, 0, 0}}, [], %{
       metadata: [],


### PR DESCRIPTION
We're using logstash-json in couple our projects and sending our logs to Kibana. We needed a way to send indexable attributes, since Kibana (https://www.elastic.co/guide/en/kibana/master/nested-objects.html) is not allowing us to index `metadata` from log outputs. By this PR, I tried to pull desired `metadata` attributes to top leve JSON payload.