### PR TITLE
Serialize structures in metadata to maps

### DIFF
--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -67,7 +67,7 @@ defmodule LogstashJson.Event do
   # Traverse complex objects and inspect PID's to their string representation
   defp print_pids(it) when is_pid(it),   do: inspect(it)
   defp print_pids(it) when is_list(it),  do: Enum.map it, &print_pids/1
-  defp print_pids(it) when is_tuple(it), do: List.to_tuple(print_pids(Tuple.to_list(it)))
+  defp print_pids(it) when is_tuple(it), do: print_pids(Tuple.to_list(it))
   defp print_pids(%_{} = it),            do: print_pids(Map.from_struct(it))
   defp print_pids(it) when is_map(it),   do: Enum.into(it, %{}, fn {k, v} -> {k, print_pids(v)} end)
   defp print_pids(it), do: it

--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -68,6 +68,7 @@ defmodule LogstashJson.Event do
   defp print_pids(it) when is_pid(it),   do: inspect(it)
   defp print_pids(it) when is_list(it),  do: Enum.map it, &print_pids/1
   defp print_pids(it) when is_tuple(it), do: List.to_tuple(print_pids(Tuple.to_list(it)))
+  defp print_pids(%_{} = it),            do: print_pids(Map.from_struct(it))
   defp print_pids(it) when is_map(it),   do: Enum.into(it, %{}, fn {k, v} -> {k, print_pids(v)} end)
   defp print_pids(it), do: it
 end

--- a/lib/logstash_json_console.ex
+++ b/lib/logstash_json_console.ex
@@ -65,7 +65,7 @@ defmodule LogstashJson.Console do
       {:ok, log} ->
         IO.puts log
       {:error, reason} ->
-        IO.puts "Failed to serialize event. error: #{reason}, event: #{inspect event}"
+        IO.puts "Failed to serialize event. error: #{inspect reason}, event: #{inspect event}"
     end
   end
 end

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -64,6 +64,11 @@ defmodule EventTest do
     assert %{"message" => "Hello", "metadata" => %{"foo" => %{"bar" => "baz"}}} = event
   end
 
+  test "Serializes tuples to lists" do
+    event = log_json("Hello", %{}, [foo: {:bar, :baz}]) |> Poison.decode!()
+    assert %{"message" => "Hello", "metadata" => %{"foo" => ["bar", "baz"]}} = event
+  end
+
   defp log(msg, fields \\ %{}, metadata \\ []) do
     Event.event(:info, msg, {{2015, 1, 1}, {0, 0, 0, 0}}, metadata, %{
       fields: fields,

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -2,6 +2,10 @@ defmodule EventTest do
   use ExUnit.Case, async: false
   alias LogstashJson.Event
 
+  defmodule Foo do
+    defstruct [:bar]
+  end
+
   test "Creates and serializes event" do
     message = "Meow meow"
     event = log(message)
@@ -55,6 +59,11 @@ defmodule EventTest do
       |> Map.get(:metadata) == %{foo: "Bar"}
   end
 
+  test "Serializes structs to maps" do
+    event = log_json("Hello", %{}, [foo: %Foo{bar: "baz"}]) |> Poison.decode!()
+    assert %{"message" => "Hello", "metadata" => %{"foo" => %{"bar" => "baz"}}} = event
+  end
+
   defp log(msg, fields \\ %{}, metadata \\ []) do
     Event.event(:info, msg, {{2015, 1, 1}, {0, 0, 0, 0}}, metadata, %{
       fields: fields,
@@ -62,8 +71,8 @@ defmodule EventTest do
     })
   end
 
-  defp log_json(msg, fields \\ %{}) do
-    {:ok, l} = Event.json(log(msg, fields))
+  defp log_json(msg, fields \\ %{}, metadata \\ []) do
+    {:ok, l} = Event.json(log(msg, fields, metadata))
     l
   end
 end


### PR DESCRIPTION
Some 3rd-party libraries may inject arbitrary structs into Logger metadata. For example, [tapper](https://github.com/Financial-Times/tapper/blob/master/lib/tapper/tracer.ex#L73).

Such structure leads to crashing the Logstash logger handler with error
```
(Protocol.UndefinedError) protocol Enumerable not implemented for #Tapper.TraceId<...>
```

This commit converts all structures into maps before trying to serialize it.