### PR TITLE
🐛 Fix milliseconds precision in log messages

### DIFF
--- a/lib/logstash_json/event.ex
+++ b/lib/logstash_json/event.ex
@@ -61,7 +61,7 @@ defmodule LogstashJson.Event do
   end
 
   defp datetime({{year, month, day}, {hour, min, sec, millis}}) do
-    {:ok, ndt} = NaiveDateTime.new(year, month, day, hour, min, sec, {millis, 3})
+    {:ok, ndt} = NaiveDateTime.new(year, month, day, hour, min, sec, {millis * 1000, 3})
     NaiveDateTime.to_iso8601(ndt)
   end
 

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -14,7 +14,7 @@ defmodule EventTest do
 
     assert Map.get(event, :message) == message
     assert Map.get(event, :level) == :info
-    assert String.starts_with?(time, "2015-04-19T08:15:03.000")
+    assert String.starts_with?(time, "2015-04-19T08:15:03.028")
     assert String.length(time) == 29
   end
 


### PR DESCRIPTION
The `NaiveDateTime.new/1` expects microseconds, not
milliseconds. Multiplying by 1000 fixes the problem.