### PR TITLE
print_pids -> pre_encode, check for custom Poison.Encoder protocol impl

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LogstashJson.Mixfile do
   def project do
     [
       app: :logstash_json,
-      version: "0.7.4",
+      version: "0.7.5",
       elixir: "~> 1.4",
       description: description(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule LogstashJson.Mixfile do
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
+      consolidate_protocols: Mix.env() != :test,
       deps: deps()
     ]
   end

--- a/test/event_test.exs
+++ b/test/event_test.exs
@@ -6,6 +6,17 @@ defmodule EventTest do
     defstruct [:bar]
   end
 
+  defmodule Hello do
+    defstruct [:world]
+  end
+
+  defimpl Poison.Encoder, for: Hello do
+    def encode(%Hello{}, opts) do
+      "HELLO_WORLD"
+      |> Poison.Encoder.BitString.encode(opts)
+    end
+  end
+
   test "Creates and serializes event" do
     message = "Meow meow"
     event = log(message)
@@ -104,6 +115,11 @@ defmodule EventTest do
   test "Formatter is used" do
     assert log("Something", %{}, [], &Map.put(&1, :hello, "there"))
            |> Map.get(:hello) == "there"
+  end
+
+  test "use existing implementation of Poison.Encoder" do
+    event = log_json("Hello", %{}, hello: %Hello{}) |> Poison.decode!()
+    assert %{"message" => "Hello", "hello" => "HELLO_WORLD"} = event
   end
 
   defp log(msg, fields \\ %{}, metadata \\ [], formatter \\ & &1) do


### PR DESCRIPTION
- rename `print_pids` -> `pre_encode` (better naming)
- in `pre_encode` clause for Elixir struct, convert struct to map only if `Poison.Encoder` protocol is not implemented for this data type